### PR TITLE
Use fnctl lock instead of flock on unix

### DIFF
--- a/leveldb/storage/file_storage_unix.go
+++ b/leveldb/storage/file_storage_unix.go
@@ -49,15 +49,20 @@ func newFileLock(path string, readOnly bool) (fl fileLock, err error) {
 }
 
 func setFileLock(f *os.File, readOnly, lock bool) error {
-	how := syscall.LOCK_UN
+	flock := syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Start:  0,
+		Len:    0,
+		Whence: 1,
+	}
 	if lock {
 		if readOnly {
-			how = syscall.LOCK_SH
+			flock.Type = syscall.F_RDLCK
 		} else {
-			how = syscall.LOCK_EX
+			flock.Type = syscall.F_WRLCK
 		}
 	}
-	return syscall.Flock(int(f.Fd()), how|syscall.LOCK_NB)
+	return syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &flock)
 }
 
 func rename(oldpath, newpath string) error {


### PR DESCRIPTION
Our nodejs library is a direct wrapper for the original leveldb c++ code. That code uses fnctl locks to secure access to the db, while the golang library we forked uses flocks. On linux, flocks have an independent implementation from fnctl locks which means the two are incompatible whereas on other systems, flocks are implemented using fnctl locks.

The most important difference between the two (for us) is that fnctl locks map processes/pids to files. That means that a single lock is acquired for a single pid to access a given file. It does not allow for multi-threaded single processes which would use the same pid but otherwise uncoordinated access attempts within the code. Flocks maps a file handler to a file. This does allow for multi-threading because each thread would have a distinct file handler open to the file.

This change is not more or less correct than using a flock, all it does it make it more compatible with other leveldb libraries that are implemented as bindings of the original c++ code, but there are benefits/detriments to doing it either way.

[Here](https://lwn.net/Articles/586904/) is a good resource on locks